### PR TITLE
Remove Name Tag picture for School Uniform

### DIFF
--- a/_general-information/School Services/Uniform Supplier.md
+++ b/_general-information/School Services/Uniform Supplier.md
@@ -29,9 +29,6 @@ more operating details.</p>
 <tr>
 <td rowspan="1" colspan="1">
 <p></p>
-<div class="isomer-image-wrapper">
-<img style="width: 100%" height="auto" width="100%" alt="" src="/images/2024 Others/SchUniform_NameTag.jpg">
-</div>
 </td>
 <td rowspan="1" colspan="1">
 <p></p>


### PR DESCRIPTION
Name Tag picture is too high. Remove and replace later with correct picture.